### PR TITLE
added darkmode to layout for all pages

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
 <html>
+  <style>
+    body.dark {
+    background: #1f1f1f;
+    color: #eaeaea;
+    }
+    .controls {
+    position: fixed;
+    bottom: 0em;
+    right: 0em;
+    }
+  </style>
   <body>
     <header>
       <div class="container">
@@ -18,4 +29,18 @@
       {% endblock %}
     </div>
   </body>
+  <div class="controls">
+    <a href="#" class="toggle-bg">
+      <svg width="100" height="100">
+              <circle cx="22" cy="22" r="20" stroke="white" stroke-width="2" fill="black" />
+      </svg>
+    </a>
+  </div>
+  <script>
+      document.querySelector('.toggle-bg').addEventListener('click', function(e) {
+      e.preventDefault();
+      document.body.classList.toggle('dark');
+      })
+  </script>
+
 </html>


### PR DESCRIPTION
Moved dark-mode button into layout template so it applies to all pages. It does not carry over when loading new page, only works in single page. 